### PR TITLE
FIX singular de garras

### DIFF
--- a/DefInjected/BodyPartGroupDef/BodyPartGroups.xml
+++ b/DefInjected/BodyPartGroupDef/BodyPartGroups.xml
@@ -14,7 +14,7 @@
   <Feet.label>pés</Feet.label>
   
   <!-- EN: front left claws -->
-  <FrontLeftClaws.label>garras esquerda dianteira</FrontLeftClaws.label>
+  <FrontLeftClaws.label>garra dianteira esquerda</FrontLeftClaws.label>
   <!-- EN: claws -->
   <FrontLeftClaws.labelShort>garra</FrontLeftClaws.labelShort>
   
@@ -29,7 +29,7 @@
   <FrontLeftPaw.labelShort>pata</FrontLeftPaw.labelShort>
   
   <!-- EN: front right claws -->
-  <FrontRightClaws.label>garras direita dianteira</FrontRightClaws.label>
+  <FrontRightClaws.label>garra dianteira direita</FrontRightClaws.label>
   <!-- EN: claws -->
   <FrontRightClaws.labelShort>garra</FrontRightClaws.labelShort>
   


### PR DESCRIPTION
Um exemplo de uso de "front left claws" em RimWorld se dará em Iguana, a qual só possui 2 garras dianteiras: 1 esquerda e 1 direita. Então creio que no caso, a tradução deva ser no singular.

Me permiti alterar a ordem os qualificadores também (dianteiro e esquerdo) por uma forma mais comum, ou mais apropriada.