### PR TITLE
Corpos de Insectoides

### DIFF
--- a/Core/DefInjected/BodyDef/Bodies_Animal_Insect.xml
+++ b/Core/DefInjected/BodyDef/Bodies_Animal_Insect.xml
@@ -2,11 +2,11 @@
 <LanguageData>
   
   <!-- EN: beetle-like -->
-  <BeetleLike.label>insectóide</BeetleLike.label>
+  <BeetleLike.label>insectoide</BeetleLike.label>
   <!-- EN: left elytra -->
-  <BeetleLike.corePart.parts.left_elytra.customLabel>asa esquerda</BeetleLike.corePart.parts.left_elytra.customLabel>
+  <BeetleLike.corePart.parts.left_elytra.customLabel>élitro esquerdo</BeetleLike.corePart.parts.left_elytra.customLabel>
   <!-- EN: right elytra -->
-  <BeetleLike.corePart.parts.right_elytra.customLabel>asa direita</BeetleLike.corePart.parts.right_elytra.customLabel>
+  <BeetleLike.corePart.parts.right_elytra.customLabel>élitro direito</BeetleLike.corePart.parts.right_elytra.customLabel>
   <!-- EN: left eye -->
   <BeetleLike.corePart.parts.Pronotum.parts.InsectHead.parts.left_eye.customLabel>olho esquerdo</BeetleLike.corePart.parts.Pronotum.parts.InsectHead.parts.left_eye.customLabel>
   <!-- EN: right eye -->
@@ -20,20 +20,20 @@
   <!-- EN: front right leg -->
   <BeetleLike.corePart.parts.front_right_leg.customLabel>perna dianteira direita</BeetleLike.corePart.parts.front_right_leg.customLabel>
   <!-- EN: middle left leg -->
-  <BeetleLike.corePart.parts.middle_left_leg.customLabel>perna do meio esquerda</BeetleLike.corePart.parts.middle_left_leg.customLabel>
+  <BeetleLike.corePart.parts.middle_left_leg.customLabel>perna média esquerda</BeetleLike.corePart.parts.middle_left_leg.customLabel>
   <!-- EN: middle right leg -->
-  <BeetleLike.corePart.parts.middle_right_leg.customLabel>perna do meio direita</BeetleLike.corePart.parts.middle_right_leg.customLabel>
+  <BeetleLike.corePart.parts.middle_right_leg.customLabel>perna média direita</BeetleLike.corePart.parts.middle_right_leg.customLabel>
   <!-- EN: rear left leg -->
   <BeetleLike.corePart.parts.rear_left_leg.customLabel>perna traseira esquerda</BeetleLike.corePart.parts.rear_left_leg.customLabel>
   <!-- EN: rear right leg -->
   <BeetleLike.corePart.parts.rear_right_leg.customLabel>perna traseira direita</BeetleLike.corePart.parts.rear_right_leg.customLabel>
   
   <!-- EN: beetle-like with claw -->
-  <BeetleLikeWithClaw.label>insectóide com garra</BeetleLikeWithClaw.label>
+  <BeetleLikeWithClaw.label>insectoide com garra</BeetleLikeWithClaw.label>
   <!-- EN: left elytra -->
-  <BeetleLikeWithClaw.corePart.parts.left_elytra.customLabel>asa esquerda</BeetleLikeWithClaw.corePart.parts.left_elytra.customLabel>
+  <BeetleLikeWithClaw.corePart.parts.left_elytra.customLabel>élitro esquerdo</BeetleLikeWithClaw.corePart.parts.left_elytra.customLabel>
   <!-- EN: right elytra -->
-  <BeetleLikeWithClaw.corePart.parts.right_elytra.customLabel>asa direita</BeetleLikeWithClaw.corePart.parts.right_elytra.customLabel>
+  <BeetleLikeWithClaw.corePart.parts.right_elytra.customLabel>élitro direito</BeetleLikeWithClaw.corePart.parts.right_elytra.customLabel>
   <!-- EN: left eye -->
   <BeetleLikeWithClaw.corePart.parts.Pronotum.parts.InsectHead.parts.left_eye.customLabel>olho esquerdo</BeetleLikeWithClaw.corePart.parts.Pronotum.parts.InsectHead.parts.left_eye.customLabel>
   <!-- EN: right eye -->
@@ -47,9 +47,9 @@
   <!-- EN: front right leg -->
   <BeetleLikeWithClaw.corePart.parts.front_right_leg.customLabel>perna dianteira direita</BeetleLikeWithClaw.corePart.parts.front_right_leg.customLabel>
   <!-- EN: middle left leg -->
-  <BeetleLikeWithClaw.corePart.parts.middle_left_leg.customLabel>perna do meio esquerda</BeetleLikeWithClaw.corePart.parts.middle_left_leg.customLabel>
+  <BeetleLikeWithClaw.corePart.parts.middle_left_leg.customLabel>perna média esquerda</BeetleLikeWithClaw.corePart.parts.middle_left_leg.customLabel>
   <!-- EN: middle right leg -->
-  <BeetleLikeWithClaw.corePart.parts.middle_right_leg.customLabel>perna do meio direita</BeetleLikeWithClaw.corePart.parts.middle_right_leg.customLabel>
+  <BeetleLikeWithClaw.corePart.parts.middle_right_leg.customLabel>perna média direita</BeetleLikeWithClaw.corePart.parts.middle_right_leg.customLabel>
   <!-- EN: rear left leg -->
   <BeetleLikeWithClaw.corePart.parts.rear_left_leg.customLabel>perna traseira esquerda</BeetleLikeWithClaw.corePart.parts.rear_left_leg.customLabel>
   <!-- EN: rear right leg -->


### PR DESCRIPTION
"Insectóide" -> "Insectoide"

Explicação: -oide não tem acento por o ditongo aberto "oi" estar na penúltima sílaba.

"Asa" -> "Élitro"

Explicação: termo anatômico correto para "asa de insetos".

"Perna do meio" -> "Perna média"

Explicação: manter consistência em locuções adjetivas na descrição de pernas em "BodyDefs".