### PR TITLE
Update Relics.xml

### DIFF
--- a/Ideology/DefInjected/ThingDef/Relics.xml
+++ b/Ideology/DefInjected/ThingDef/Relics.xml
@@ -23,7 +23,7 @@
   <RelicInertBox.comps.CompProperties_Usable.useLabel>Ativar</RelicInertBox.comps.CompProperties_Usable.useLabel>
 
   <!-- EN: tablet -->
-  <RelicInertTablet.label>tablete</RelicInertTablet.label>
+  <RelicInertTablet.label>tábua</RelicInertTablet.label>
   <!-- EN: An object with ideoligious significance. -->
   <RelicInertTablet.description>Um objeto com significado ideológico.</RelicInertTablet.description>
   <!-- EN: Activate -->


### PR DESCRIPTION
Onde o original é "tablet" e foi traduzido para "tablete", o mais correto seria "tábua", devido ao contexto religioso/ideológico da DLC. Algo como tábua dos dez mandamentos.