### PR TITLE
Correção

### DIFF
--- a/Royalty/DefInjected/ThingDef/MeleeBladelink.xml
+++ b/Royalty/DefInjected/ThingDef/MeleeBladelink.xml
@@ -2,9 +2,9 @@
 <LanguageData>
   
   <!-- EN: persona monosword -->
-  <MeleeWeapon_MonoSwordBladelink.label>mono-espada persona</MeleeWeapon_MonoSwordBladelink.label>
+  <MeleeWeapon_MonoSwordBladelink.label>espada monomolecular persona</MeleeWeapon_MonoSwordBladelink.label>
   <!-- EN: A crystal-metallic longsword infused with mechanites that maintain a mono-molecular cutting edge. It cuts through even thick armor with ease, while its light weight and onboard persona permit extremely fast attacks.\n\nThis weapon has an onboard persona that can bond to only a single person. The wielder and intelligent weapon can synchronize their reflexes and attack with frightening speed, accuracy, and creativity. Once bonded to a wielder, the weapon's persona will refuse to be wielded by anyone else. -->
-  <MeleeWeapon_MonoSwordBladelink.description>Uma espada longa cristalina e metálica infundida com mecanitos que mantêm uma ponta monomolecular. Ele corta com facilidade até armaduras grossas, enquanto seu peso leve e sua personalidade embutida permitem ataques extremamente rápidos.\n\nEsta arma possui uma personalidade embutida que pode se unir a apenas uma pessoa. O portador e a arma inteligente podem sincronizar seus reflexos e atacar com uma velocidade assustadora, precisão e criatividade. Uma vez vinculada a um portador, a personalidade da arma se recusará a ser manejada por qualquer outra pessoa.</MeleeWeapon_MonoSwordBladelink.description>
+  <MeleeWeapon_MonoSwordBladelink.description>Uma espada longa metálico cristalina infundida com mecanitos que sustenta uma lâmina de corte monomolecular. Ela corta com facilidade até armaduras grossas, enquanto seu peso leve e sua personalidade embutida permitem ataques extremamente rápidos.\n\nEsta arma possui uma personalidade embutida que pode se unir a apenas uma pessoa. O portador e a arma inteligente podem sincronizar seus reflexos e atacar com uma velocidade assustadora, precisão e criatividade. Uma vez vinculada a um portador, a personalidade da arma se recusará a ser manejada por qualquer outra pessoa.</MeleeWeapon_MonoSwordBladelink.description>
   <!-- EN: handle -->
   <MeleeWeapon_MonoSwordBladelink.tools.handle.label>cabo</MeleeWeapon_MonoSwordBladelink.tools.handle.label>
   <!-- EN: point -->

--- a/Royalty/DefInjected/ThingDef/MeleeBladelink.xml
+++ b/Royalty/DefInjected/ThingDef/MeleeBladelink.xml
@@ -13,7 +13,7 @@
   <MeleeWeapon_MonoSwordBladelink.tools.edge.label>lâmina</MeleeWeapon_MonoSwordBladelink.tools.edge.label>
   
   <!-- EN: persona plasmasword -->
-  <MeleeWeapon_PlasmaSwordBladelink.label>espada-de-plasma persona</MeleeWeapon_PlasmaSwordBladelink.label>
+  <MeleeWeapon_PlasmaSwordBladelink.label>espada de plasma persona</MeleeWeapon_PlasmaSwordBladelink.label>
   <!-- EN: A metal-cored sword with a cutting edge. Plasma is wrapped around the core, held in place by an energy field. Targets are both sliced by the metal core, as well as burned or ignited by the plasma sheath.\n\nThis weapon has an onboard persona that can bond to only a single person. The wielder and intelligent weapon can synchronize their reflexes and attack with frightening speed, accuracy, and creativity. Once bonded to a wielder, the weapon's persona will refuse to be wielded by anyone else. -->
   <MeleeWeapon_PlasmaSwordBladelink.description>Uma espada de metal com uma lâmina cortante. O plasma é enrolado em volta do núcleo, mantido no lugar por um campo de energia. Os alvos são fatiados pelo núcleo de metal e queimados ou inflamados pela bainha de plasma.\n\nEsta arma possui uma personalidade embutida que pode se unir a apenas uma pessoa. O portador e a arma inteligente podem sincronizar seus reflexos e atacar com uma velocidade assustadora, precisão e criatividade. Uma vez vinculada a um portador, a personalidade da arma se recusará a ser manejada por qualquer outra pessoa.</MeleeWeapon_PlasmaSwordBladelink.description>
   <!-- EN: handle -->
@@ -24,7 +24,7 @@
   <MeleeWeapon_PlasmaSwordBladelink.tools.edge.label>lâmina</MeleeWeapon_PlasmaSwordBladelink.tools.edge.label>
   
   <!-- EN: persona zeushammer -->
-  <MeleeWeapon_ZeusHammerBladelink.label>martelo-de-zeus persona</MeleeWeapon_ZeusHammerBladelink.label>
+  <MeleeWeapon_ZeusHammerBladelink.label>martelo de zeus persona</MeleeWeapon_ZeusHammerBladelink.label>
   <!-- EN: A warhammer with an embedded EMP capacitor. Upon impact, it blasts the target with an EMP burst in addition to the physical damage.\n\nThis weapon has an onboard persona that can bond to only a single person. The wielder and intelligent weapon can synchronize their reflexes and attack with frightening speed, accuracy, and creativity. Once bonded to a wielder, the weapon's persona will refuse to be wielded by anyone else. -->
   <MeleeWeapon_ZeusHammerBladelink.description>Um martelo de guerra com um capacitor de PEM embutido. Após o impacto, ele atinge o alvo com uma explosão de PEM, além do dano físico.\n\nEsta arma possui uma personalidade embutida que pode se unir a apenas uma pessoa. O portador e a arma inteligente podem sincronizar seus reflexos e atacar com uma velocidade assustadora, precisão e criatividade. Uma vez vinculada a um portador, a personalidade da arma se recusará a ser manejada por qualquer outra pessoa.</MeleeWeapon_ZeusHammerBladelink.description>
   <!-- EN: handle -->

--- a/Royalty/DefInjected/ThingDef/MeleeUltratech.xml
+++ b/Royalty/DefInjected/ThingDef/MeleeUltratech.xml
@@ -13,7 +13,7 @@
   <MeleeWeapon_MonoSword.tools.edge.label>lâmina</MeleeWeapon_MonoSword.tools.edge.label>
   
   <!-- EN: plasmasword -->
-  <MeleeWeapon_PlasmaSword.label>espada-de-plasma</MeleeWeapon_PlasmaSword.label>
+  <MeleeWeapon_PlasmaSword.label>espada de plasma</MeleeWeapon_PlasmaSword.label>
   <!-- EN: A metal-cored sword with a cutting edge. Plasma is wrapped around the core, held in place by an energy field. Targets are both sliced by the metal core, as well as burned or ignited by the plasma sheath. -->
   <MeleeWeapon_PlasmaSword.description>Uma espada de metal uma lâmina cortante. O plasma é enrolado em volta do núcleo, mantido no lugar por um campo de energia. Os alvos são fatiados pelo núcleo de metal, assim como queimados ou inflamados pela bainha de plasma.</MeleeWeapon_PlasmaSword.description>
   <!-- EN: handle -->
@@ -24,7 +24,7 @@
   <MeleeWeapon_PlasmaSword.tools.edge.label>lâmina</MeleeWeapon_PlasmaSword.tools.edge.label>
   
   <!-- EN: zeushammer -->
-  <MeleeWeapon_Zeushammer.label>martelo-de-zeus</MeleeWeapon_Zeushammer.label>
+  <MeleeWeapon_Zeushammer.label>martelo de zeus</MeleeWeapon_Zeushammer.label>
   <!-- EN: A warhammer with an embedded EMP capacitor. Upon impact, it blasts the target with an EMP burst in addition to the physical damage. -->
   <MeleeWeapon_Zeushammer.description>Um martelo de guerra com um capacitor PEM embutido. Após o impacto, ele atinge o alvo com uma explosão de PEM, além do dano físico.</MeleeWeapon_Zeushammer.description>
   <!-- EN: handle -->

--- a/Royalty/DefInjected/ThingDef/MeleeUltratech.xml
+++ b/Royalty/DefInjected/ThingDef/MeleeUltratech.xml
@@ -2,9 +2,9 @@
 <LanguageData>
   
   <!-- EN: monosword -->
-  <MeleeWeapon_MonoSword.label>mono-espada</MeleeWeapon_MonoSword.label>
+  <MeleeWeapon_MonoSword.label>espada monomolecular</MeleeWeapon_MonoSword.label>
   <!-- EN: A crystal-metallic longsword infused with mechanites that maintain a mono-molecular cutting edge. It cuts through even thick armor with ease, and its light weight permits fast attacks. -->
-  <MeleeWeapon_MonoSword.description>Uma espada longa cristalina e metálica infundida com mecanitos que mantêm uma ponta monomolecular. Ela corta com facilidade até armaduras grossas e seu peso leve permite ataques rápidos.</MeleeWeapon_MonoSword.description>
+  <MeleeWeapon_MonoSword.description>Uma espada longa metálico cristalina infundida com mecanitos que sustenta uma lâmina de corte monomolecular. Ela corta com facilidade até mesmo armaduras grossas, além de seu peso leve permitir ataques rápidos.</MeleeWeapon_MonoSword.description>
   <!-- EN: handle -->
   <MeleeWeapon_MonoSword.tools.handle.label>cabo</MeleeWeapon_MonoSword.tools.handle.label>
   <!-- EN: point -->


### PR DESCRIPTION
o termo "espada-de-plasma" não se encaixa nas circunstâncias linguísticas que requerem o uso do "-". O mesmo serve para "martelo-de-zeus".