### PR TITLE
1.4 / Core - Backstories: Adult_Tribal & Child_Tribal

### DIFF
--- a/Core/DefInjected/BackstoryDef/Tribal_Adult.xml
+++ b/Core/DefInjected/BackstoryDef/Tribal_Adult.xml
@@ -9,49 +9,49 @@
   <Archer25.titleShort>Arqueiro</Archer25.titleShort>
   
   <!-- EN: [PAWN_nameDef]'s tribe banished [PAWN_objective] following a bloody dispute. [PAWN_pronoun] survived in the wilds alone for a long time. -->
-  <Banished68.baseDesc>[PAWN_nameDef] foi banido da sua tribo após uma disputa sangrenta. [PAWN_pronoun] sobreviveu na selva sozinho por um longo tempo.</Banished68.baseDesc>
+  <Banished68.baseDesc>[PAWN_nameDef] foi banid{PAWN_gender ? o : a} da sua tribo após uma disputa sangrenta. [PAWN_pronoun] sobreviveu na selva sozinh{PAWN_gender ? o : a} por um longo tempo.</Banished68.baseDesc>
   <!-- EN: banished -->
   <Banished68.title>Banido</Banished68.title>
   <!-- EN: banished -->
   <Banished68.titleShort>Banido</Banished68.titleShort>
   
   <!-- EN: [PAWN_nameDef] wielded ikwa, axes, clubs, and other close-ranged weapons in battles for [PAWN_possessive] tribe. -->
-  <Brave88.baseDesc>[PAWN_nameDef] empunhava ikwa, machados, paus e outras armas de curto alcance em batalhas pela sua tribo.</Brave88.baseDesc>
+  <Brave88.baseDesc>[PAWN_nameDef] empunhava ikwa, machados, porretes e outras armas de curto alcance em batalhas pela sua tribo.</Brave88.baseDesc>
   <!-- EN: brave -->
   <Brave88.title>Bravo</Brave88.title>
   <!-- EN: brave -->
   <Brave88.titleShort>Bravo</Brave88.titleShort>
   
   <!-- EN: [PAWN_nameDef]'s main job in the hunting party was the butchering of animals. [PAWN_pronoun] became a master with the knife, able to extract every bit of value from a carcass in a short time. -->
-  <Butcher40.baseDesc>O trabalho principal de [PAWN_nameDef] era abater animais. [PAWN_pronoun] se tornou um mestre com a faca, conseguindo extrair cada parte nobre de uma carcassa de maneira extremamente rápida.</Butcher40.baseDesc>
+  <Butcher40.baseDesc>O principal trabalho de [PAWN_nameDef] no grupo de caça era o abate de animais. [PAWN_pronoun] se tornou um mestre com a faca, conseguindo extrair cada parte nobre de uma carcaça de maneira extremamente rápida.</Butcher40.baseDesc>
   <!-- EN: butcher -->
   <Butcher40.title>Açougueiro</Butcher40.title>
   <!-- EN: butcher -->
   <Butcher40.titleShort>Aoçougueiro</Butcher40.titleShort>
   
   <!-- EN: [PAWN_nameDef] carved artworks for [PAWN_possessive] tribe from wood, stone, and occasionally, more exotic materials. The work was sometimes sold, and sometimes kept to beautify settlements and provide a focus for rituals. -->
-  <Carver1.baseDesc>[PAWN_nameDef] esculpiu obras de arte para sua tribo em madeira, pedra e ocasionalmente, materiais mais exóticos. O trabalho às vezes era vendido, e às vezes mantido para embelezar assentamentos e fornecer um foco para rituais.</Carver1.baseDesc>
+  <Carver1.baseDesc>[PAWN_nameDef] esculpiu obras de arte para sua tribo a partir de madeira, pedra e ocasionalmente, materiais mais exóticos. O trabalho às vezes era vendido, e às vezes mantido para embelezar assentamentos e fornecer foco para rituais.</Carver1.baseDesc>
   <!-- EN: carver -->
   <Carver1.title>Entalhador</Carver1.title>
   <!-- EN: carver -->
   <Carver1.titleShort>Entalhador</Carver1.titleShort>
   
   <!-- EN: [PAWN_nameDef] specialized in cave complex excavation and construction. -->
-  <CaveBuilder81.baseDesc>[PAWN_nameDef] é um especialista na escavação e construção de cavernas enormes.</CaveBuilder81.baseDesc>
+  <CaveBuilder81.baseDesc>[PAWN_nameDef] é u{PAWN_gender ? m : ma} especialista na escavação e construção de complexos de cavernas.</CaveBuilder81.baseDesc>
   <!-- EN: cave builder -->
-  <CaveBuilder81.title>Excavador de cavernas</CaveBuilder81.title>
+  <CaveBuilder81.title>Construtor de cavernas</CaveBuilder81.title>
   <!-- EN: cave builder -->
-  <CaveBuilder81.titleShort>Excavador de cavernas</CaveBuilder81.titleShort>
+  <CaveBuilder81.titleShort>Construtor de cavernas</CaveBuilder81.titleShort>
   
   <!-- EN: [PAWN_nameDef] labored in mines and caves, digging out spaces for storing items and hiding from threats. [PAWN_possessive] work provided hiding spots for [PAWN_possessive] friends on many occasions. -->
-  <Digger31.baseDesc>[PAWN_nameDef] explorou minas se cavernas, cavando espaços para se esconder de perigos e guardar itens. [PAWN_possessive] seu trabalho permitiu que seus amigos se escondessem várias vezes.</Digger31.baseDesc>
+  <Digger31.baseDesc>[PAWN_nameDef] trabalhou em minas e cavernas, cavando espaços para se esconder de perigos e guardar itens. Seu trabalho forneceu esconderijo para seus amigos sem várias ocasiões.</Digger31.baseDesc>
   <!-- EN: digger -->
   <Digger31.title>Tatu-cavador</Digger31.title>
   <!-- EN: digger -->
   <Digger31.titleShort>Tatu-cavador</Digger31.titleShort>
   
   <!-- EN: [PAWN_nameDef] carved living spaces and mined minerals from the sides of hills and mountains. [PAWN_pronoun] learned to feel at home picking through rock and shoring up cave walls. -->
-  <Digger66.baseDesc>[PAWN_nameDef] e sua tribo esculpiram sua casa profundamente no lado de uma montanha. [PAWN_nameDef] se sente mais em casa escolhendo através da rocha e escorando nas paredes da caverna.</Digger66.baseDesc>
+  <Digger66.baseDesc>[PAWN_nameDef] esculpiu áreas de habitação e extraiu minerais das encostas de colinas e montanhas. [PAWN_nameDef] aprendeu a se sentir em casa escavando através das rochas e escorando paredes de cavernas.</Digger66.baseDesc>
   <!-- EN: digger -->
   <Digger66.title>Escavador</Digger66.title>
   <!-- EN: digger -->
@@ -65,25 +65,25 @@
   <Excavator55.titleShort>Escavador</Excavator55.titleShort>
   
   <!-- EN: [PAWN_nameDef] was responsible for erecting structures for [PAWN_possessive] fellow tribespeople to live in. This included both temporary structures for nomadic travel, and permanent settlements. Gathering building materials from local plant life was part of the job. -->
-  <Framer37.baseDesc>[PAWN_nameDef] foi responsável por erguer estruturas para seus companheiros de tribo viverem. Isso incluía estruturas temporárias para viagens nômades e assentamentos permanentes. Reunir materiais de construção, da vegetação local fazia parte do trabalho.</Framer37.baseDesc>
+  <Framer37.baseDesc>[PAWN_nameDef] foi responsável por erguer estruturas para seus companheiros de tribo viverem. Isso incluía estruturas temporárias para viagens nômades e assentamentos permanentes. Reunir materiais de construção da vegetação local fazia parte do trabalho.</Framer37.baseDesc>
   <!-- EN: framer -->
-  <Framer37.title>Emoldurador</Framer37.title>
+  <Framer37.title>Planejador de estrutura</Framer37.title>
   <!-- EN: framer -->
-  <Framer37.titleShort>Emoldurador</Framer37.titleShort>
+  <Framer37.titleShort>Planejador de estrutura</Framer37.titleShort>
   
   <!-- EN: Using [PAWN_possessive] knowledge of plants, roots, and berries, [PAWN_nameDef] could find food in even the most barren landscapes. [PAWN_pronoun] stayed away from animals. -->
-  <Gatherer70.baseDesc>[PAWN_nameDef] é um coletor mestre. [PAWN_pronoun] pode encontrar comida no mais estéril dos lugares usando seu conhecimento profundo de plantas, raízes e frutos silvestres.</Gatherer70.baseDesc>
+  <Gatherer70.baseDesc>Usando seu conhecimento sobre plantas, raízes e frutos, [PAWN_nameDef] pode encontrar comida até mesmo nas paisagens mais áridas. [PAWN_pronoun] prefere ficar longe de animais.</Gatherer70.baseDesc>
   <!-- EN: gatherer -->
   <Gatherer70.title>Coletor</Gatherer70.title>
   <!-- EN: gatherer -->
   <Gatherer70.titleShort>Coletor</Gatherer70.titleShort>
   
   <!-- EN: After [PAWN_possessive] tribe's elder healer was killed in a raid, [PAWN_nameDef] took on the role. [PAWN_pronoun] spent [PAWN_possessive] days scrounging up herbs and mineral compounds from the nearby area to use in surprisingly effective remedies. -->
-  <Healer46.baseDesc>Depois que o curandeiro mais velho de sua tribo foi morto em um ataque, [PAWN_nameDef] assumiu seu papel. [PAWN_pronoun] passou os dias consumindo ervas e compostos minerais das áreas próximas, para usar remédios surpreendentemente eficazes.</Healer46.baseDesc>
+  <Healer46.baseDesc>Depois que o curandeiro mais velho de sua tribo foi morto em um ataque, [PAWN_nameDef] assumiu seu papel. [PAWN_pronoun] passou os dias juntando ervas e compostos minerais das áreas próximas, para usar em remédios surpreendentemente eficazes.</Healer46.baseDesc>
   <!-- EN: healer -->
-  <Healer46.title>Curandeira</Healer46.title>
+  <Healer46.title>Curandeiro</Healer46.title>
   <!-- EN: healer -->
-  <Healer46.titleShort>Curandeira</Healer46.titleShort>
+  <Healer46.titleShort>Curandeiro</Healer46.titleShort>
   
   <!-- EN: While the others were out hunting and foraging, [PAWN_nameDef] would stay at home to cook and take care of the young and sick. -->
   <HearthTender66.baseDesc>Enquanto os outros caçavam e procuravam comida, [PAWN_nameDef] ficava em casa para cozinhar e cuidar dos jovens e doentes.</HearthTender66.baseDesc>
@@ -93,60 +93,60 @@
   <HearthTender66.titleShort>Afetuoso</HearthTender66.titleShort>
   
   <!-- EN: [PAWN_nameDef] herded a variety of animals to help feed and clothe [PAWN_possessive] tribe while on the move. [PAWN_nameDef] learned how to calm and direct the beasts, and how to hunt [PAWN_possessive] own meals on the trail. -->
-  <Herder33.baseDesc>[PAWN_nameDef] pastorava uma variedade de animais para ajudar na alimentação e na roupa de sua tribo enquanto viajavam. [PAWN_nameDef] aprendeu como acalmar e direcionar os animais e como caçar a sua própria refeição durante a sua jornada.</Herder33.baseDesc>
+  <Herder33.baseDesc>[PAWN_nameDef] pastoreava uma variedade de animais para ajudar a alimentar e a vestir sua tribo enquanto viajavam. [PAWN_nameDef] aprendeu como acalmar e direcionar os animais, e como caçar a sua própria refeição durante a sua jornada.</Herder33.baseDesc>
   <!-- EN: herder -->
-  <Herder33.title>pastor de animais</Herder33.title>
+  <Herder33.title>Pastor</Herder33.title>
   <!-- EN: herder -->
-  <Herder33.titleShort>pastor</Herder33.titleShort>
+  <Herder33.titleShort>Pastor</Herder33.titleShort>
   
   <!-- EN: [PAWN_nameDef] tracked, trapped and killed animals for their meat and leather.\n\n[PAWN_nameDef] used both ranged and melee weapons. Sometimes, [PAWN_pronoun] hunted alongside animals. -->
-  <Hunter74.baseDesc>[PAWN_nameDef] rastreava, aprisionava e matava animais por sua carne e couro.\n\n[PAWN_nameDef] usou armas de longo alcance e corpo a corpo. Às vezes, [PAWN_pronoun] caçava ao lado de animais.</Hunter74.baseDesc>
+  <Hunter74.baseDesc>[PAWN_nameDef] rastreava, capturava com armadilhas e matava animais por sua carne e couro.\n\n[PAWN_nameDef] usou armas de longo alcance e corpo a corpo. Às vezes, [PAWN_pronoun] caçava ao lado de animais.</Hunter74.baseDesc>
   <!-- EN: hunter -->
   <Hunter74.title>Caçador</Hunter74.title>
   <!-- EN: hunter -->
   <Hunter74.titleShort>Caçador</Hunter74.titleShort>
   
   <!-- EN: [PAWN_nameDef] chopped trees and hauled their lumber back to the tribe. [PAWN_pronoun] wielded [PAWN_possessive] axe with the finesse of an artist and the force of a charging muffalo. -->
-  <Logger16.baseDesc>[PAWN_nameDef] cortou árvores e transportou sua madeira de volta para a tribo. [PAWN_pronoun] empunhava o machado com a delicadeza de um artista e a força de um múfalo.</Logger16.baseDesc>
+  <Logger16.baseDesc>[PAWN_nameDef] cortava árvores e transportava a madeira de volta para a tribo. [PAWN_pronoun] empunhava seu machado com a delicadeza de um artista e a força de um múfalo.</Logger16.baseDesc>
   <!-- EN: logger -->
   <Logger16.title>Lenhador</Logger16.title>
   <!-- EN: logger -->
   <Logger16.titleShort>Lenhador</Logger16.titleShort>
   
   <!-- EN: [PAWN_nameDef] never much liked the tribal council or the yearly festivals. [PAWN_pronoun] preferred the open plain and the whistle of wind through the rocks.\n\n[PAWN_pronoun] visited [PAWN_possessive] tribe from time to time, but mostly took care of [PAWN_objective]self using [PAWN_possessive] own survival skills. -->
-  <Loner61.baseDesc>O Solitário nunca gostou muito do conselho tribal ou das festas anuais. [PAWN_pronoun] prefere a planície aberta e o assobio solitário do vento através das rochas.\n\n[PAWN_pronoun] visita sua tribo de vez em quando, mas na maioria das vezes [PAWN_pronoun] cuida de si mesmo usando suas próprias habilidades de sobrevivência.</Loner61.baseDesc>
+  <Loner61.baseDesc>[PAWN_nameDef] nunca gostou muito do conselho tribal ou dos festivais anuais. [PAWN_pronoun] prefere a planície aberta e o assobio do vento através das rochas.\n\n[PAWN_pronoun] visitou sua tribo de tempos em tempos, mas na maioria das vezes cuidou de si mesm{PAWN_gender ? o : a} usando suas próprias habilidades de sobrevivência.</Loner61.baseDesc>
   <!-- EN: loner -->
   <Loner61.title>Solitário</Loner61.title>
   <!-- EN: loner -->
   <Loner61.titleShort>Solitário</Loner61.titleShort>
   
   <!-- EN: [PAWN_nameDef] was one of a long line of lore keepers in [PAWN_possessive] tribe. Every night around the fire, [PAWN_pronoun] would pass on ancient knowledge and helpful wisdom through stories. -->
-  <LoreKeeper51.baseDesc>[PAWN_nameDef] era um de uma longa linhagem de guardiões da sabedoria em sua tribo. Toda noite ao redor do fogo, [PAWN_pronoun] iria transmitir conhecimento antigo e sabedoria útil através de histórias.</LoreKeeper51.baseDesc>
+  <LoreKeeper51.baseDesc>[PAWN_nameDef] era um{PAWN_gender ? m : ma} de uma longa linhagem de guardiões da sabedoria em sua tribo. Toda noite ao redor do fogo, [PAWN_pronoun] trasmitiria conhecimento antigo e sabedoria útil através de histórias.</LoreKeeper51.baseDesc>
   <!-- EN: lore keeper -->
   <LoreKeeper51.title>Guardião da sabedoria</LoreKeeper51.title>
   <!-- EN: keeper -->
   <LoreKeeper51.titleShort>Guardião</LoreKeeper51.titleShort>
   
   <!-- EN: [PAWN_nameDef] often feigned sickness in order to avoid [PAWN_possessive] responsibilities. While resting in the sick hut, [PAWN_pronoun] told stories to the children. -->
-  <Malingerer28.baseDesc>[PAWN_nameDef] frequentemente fingia estar doente, para evitar suas responsabilidades. Descansando em uma cabana, enquanto estava doente, [PAWN_pronoun] contava histórias para as crianças.</Malingerer28.baseDesc>
+  <Malingerer28.baseDesc>[PAWN_nameDef] frequentemente fingia estar doente para evitar suas responsabilidades. Enquanto estava descansando na cabana dos doentes, [PAWN_pronoun] contava histórias para as crianças.</Malingerer28.baseDesc>
   <!-- EN: malingerer -->
-  <Malingerer28.title>Enganador</Malingerer28.title>
+  <Malingerer28.title>Falso doente</Malingerer28.title>
   <!-- EN: malingerer -->
-  <Malingerer28.titleShort>Enganador</Malingerer28.titleShort>
+  <Malingerer28.titleShort>Falso doente</Malingerer28.titleShort>
   
   <!-- EN: Because of [PAWN_possessive] quiet wisdom and great strength, [PAWN_nameDef] became the spiritual guide for [PAWN_possessive] tribe. [PAWN_pronoun] had a special connection with the great spirit of the muffalo. -->
-  <MuffaloShaman95.baseDesc>Por causa de sua sabedoria tranquila e grande força, [PAWN_nameDef] se tornou o líder espiritual de uma tribo nômade que seguia os rebanhos de múfalos itinerantes.</MuffaloShaman95.baseDesc>
+  <MuffaloShaman95.baseDesc>Por causa de sua silenciosa sabedoria e grande força, [PAWN_nameDef] se tornou {PAWN_gender ? o : a} guia espiritual de sua tribo. [PAWN_pronoun] tinha uma conexão especial com o grande espírito do múfalo.</MuffaloShaman95.baseDesc>
   <!-- EN: muffalo shaman -->
   <MuffaloShaman95.title>Múfalo xamã</MuffaloShaman95.title>
   <!-- EN: shaman -->
-  <MuffaloShaman95.titleShort>xamã</MuffaloShaman95.titleShort>
+  <MuffaloShaman95.titleShort>Xamã</MuffaloShaman95.titleShort>
   
   <!-- EN: [PAWN_nameDef] helped [PAWN_possessive] tribe build huge wooden structures by cutting trees into sturdy planks. [PAWN_nameDef] developed a fine understanding of how wood grows and splits. -->
-  <PlankCutter72.baseDesc>[PAWN_nameDef] ajudou sua tribo na construção de estruturas de madeiras enormes cortando a madeira em tábuas resistentes. [PAWN_nameDef] aprendeu de maneira muito eficaz como as árvores crescem e como tombam.</PlankCutter72.baseDesc>
+  <PlankCutter72.baseDesc>[PAWN_nameDef] ajudou sua tribo na construção de estruturas de madeiras enormes cortando árvores em tábuas resistentes. [PAWN_nameDef] aprendeu de maneira muito eficaz como a madeira cresce e como as dividir.</PlankCutter72.baseDesc>
   <!-- EN: plank cutter -->
-  <PlankCutter72.title>cortador de tábuas</PlankCutter72.title>
+  <PlankCutter72.title>Cortador de tábuas</PlankCutter72.title>
   <!-- EN: plank cutter -->
-  <PlankCutter72.titleShort>cortador de tábuas</PlankCutter72.titleShort>
+  <PlankCutter72.titleShort>Cortador de tábuas</PlankCutter72.titleShort>
   
   <!-- EN: Since [PAWN_possessive] tribe made contact with local outlanders, [PAWN_nameDef] contracted [PAWN_possessive] services out as a guide. Frequent contact with ancient technology made [PAWN_objective] comfortable with the lost machines. -->
   <Scout59.baseDesc>Desde que sua tribo fez contato com estrangeiros locais, [PAWN_nameDef] contratou seus serviços como guia. O contato frequente com a tecnologia antiga lhe deixava confortável com as máquinas perdidas.</Scout59.baseDesc>
@@ -156,7 +156,7 @@
   <Scout59.titleShort>Escoteiro</Scout59.titleShort>
   
   <!-- EN: [PAWN_nameDef] prepared meals from the plants and animals brought in by gatherers, farmers, and hunters of [PAWN_possessive] tribe. [PAWN_pronoun] had to make sure it was calorie-efficient, long-lasting, and healthy. [PAWN_pronoun] often processed and sometime gathered plants [PAWN_objective]self. -->
-  <StewKeeper95.baseDesc>[PAWN_nameDef] preparava refeições com as plantas e animais trazidos por coletores, agricultores e caçadores de sua tribo. [PAWN_pronoun] tinha que garantir que as refeições, fossem eficientes em calorias, duradouras e saudáveis. Muitas vezes [PAWN_pronoun] processava as plantas reunidas por si mesmo.</StewKeeper95.baseDesc>
+  <StewKeeper95.baseDesc>[PAWN_nameDef] preparava refeições com as plantas e animais trazidos por coletores, agricultores e caçadores de sua tribo. [PAWN_pronoun] tinha que garantir que as refeições, fossem eficientes em calorias, duradouras e saudáveis. Muitas vezes [PAWN_pronoun] processava as plantas coletadas por si mesm{PAWN_gender ? o : a}.</StewKeeper95.baseDesc>
   <!-- EN: stew keeper -->
   <StewKeeper95.title>Cozinheiro rústico</StewKeeper95.title>
   <!-- EN: stewkeeper -->
@@ -170,28 +170,28 @@
   <Tamer79.titleShort>Domador</Tamer79.titleShort>
   
   <!-- EN: [PAWN_nameDef] built houses among, and sometimes suspended in, the trees for [PAWN_possessive] people to use while traveling or foraging. [PAWN_nameDef] learned how to best find and use wild plants, and how to fight off wild animals. -->
-  <TreehouseBuilder86.baseDesc>[PAWN_nameDef] construia casas e, algumas delas, em cima das árvores para que as pessoas pudessem usar enquanto estivessem viajando ou buscando comidas e provisões. [PAWN_nameDef] aprendeu como identificar e usar as melhores plantas da selva e como espantar os animais selvagens.</TreehouseBuilder86.baseDesc>
+  <TreehouseBuilder86.baseDesc>[PAWN_nameDef] construía casas entre, e algumas delas suspensas, as árvores para que o seu povo pudesse usar enquanto estivesse viajando ou buscando comida e provisões. [PAWN_nameDef] aprendeu como encontrar e usar plantas selvagens da melhor forma, e como espantar os animais selvagens.</TreehouseBuilder86.baseDesc>
   <!-- EN: treehouse builder -->
-  <TreehouseBuilder86.title>Construtor de casas na árvore</TreehouseBuilder86.title>
+  <TreehouseBuilder86.title>Construtor de casas</TreehouseBuilder86.title>
   <!-- EN: treehouse builder -->
-  <TreehouseBuilder86.titleShort>Construtor de casas na árvore</TreehouseBuilder86.titleShort>
+  <TreehouseBuilder86.titleShort>Construtor de casas</TreehouseBuilder86.titleShort>
   
   <!-- EN: Following the death of a close friend by animal attack, [PAWN_nameDef] hunted the beast responsible. [PAWN_pronoun] tracked it to a nearby village, only to find one of the villagers wearing its pelt. -->
-  <VengefulHunter32.baseDesc>Após a morte de um amigo próximo por ataque de animais, [PAWN_nameDef] caçou o animal responsável. [PAWN_pronoun] o localizou em uma vila próxima, apenas para encontrar um dos moradores usando sua pele.</VengefulHunter32.baseDesc>
+  <VengefulHunter32.baseDesc>Após a morte de um amigo próximo por ataque de animal, [PAWN_nameDef] caçou o animal responsável. [PAWN_pronoun] o localizou em uma vila próxima, apenas para encontrar um dos moradores vestindo sua pele.</VengefulHunter32.baseDesc>
   <!-- EN: vengeful hunter -->
   <VengefulHunter32.title>Caçador vingativo</VengefulHunter32.title>
   <!-- EN: vengeful -->
   <VengefulHunter32.titleShort>Vingativo</VengefulHunter32.titleShort>
   
   <!-- EN: [PAWN_nameDef] was a fearsome warrior, proficient with many weapons. [PAWN_pronoun] participated in many battles. -->
-  <Warrior94.baseDesc>[PAWN_nameDef] foi um herói de guerra durante a terceira guerra mundial de seu planeta. [PAWN_pronoun] ajudou a impedir o lançamento de armas nucleares durante um impasse particularmente tenso.</Warrior94.baseDesc>
+  <Warrior94.baseDesc>[PAWN_nameDef] foi um{PAWN_gender ? m : ma} guerreiro{PAWN_gender ? o : a} temível, proficiente com muitas armas. [PAWN_pronoun] participou de muitas batalhas.</Warrior94.baseDesc>
   <!-- EN: warrior -->
   <Warrior94.title>Guerreiro</Warrior94.title>
   <!-- EN: warrior -->
   <Warrior94.titleShort>Guerreiro</Warrior94.titleShort>
   
   <!-- EN: [PAWN_nameDef] was an expert at working wool, plant fibers and natural dyes into beautiful clothing for [PAWN_possessive] kin. [PAWN_possessive] handicrafts were traded frequently with other settlements. -->
-  <Weaver63.baseDesc>[PAWN_nameDef] foi um especialista em trabalhar com lã de múfalo, fibras vegetais e corantes naturais em roupas bonitas para os seus parentes. Seus belos artesanatos eram negociados frequentemente entre tribos locais.</Weaver63.baseDesc>
+  <Weaver63.baseDesc>[PAWN_nameDef] foi u{PAWN_gender ? m : ma} especialista em trabalhar com lã, fibras vegetais e corantes naturais em roupas bonitas para os seus parentes. Seus belos artesanatos eram negociados frequentemente com outros assentamentos.</Weaver63.baseDesc>
   <!-- EN: weaver -->
   <Weaver63.title>Tecelão</Weaver63.title>
   <!-- EN: weaver -->

--- a/Core/DefInjected/BackstoryDef/Tribal_Adult.xml
+++ b/Core/DefInjected/BackstoryDef/Tribal_Adult.xml
@@ -121,7 +121,7 @@
   <Loner61.titleShort>Solitário</Loner61.titleShort>
   
   <!-- EN: [PAWN_nameDef] was one of a long line of lore keepers in [PAWN_possessive] tribe. Every night around the fire, [PAWN_pronoun] would pass on ancient knowledge and helpful wisdom through stories. -->
-  <LoreKeeper51.baseDesc>[PAWN_nameDef] era um{PAWN_gender ? m : ma} de uma longa linhagem de guardiões da sabedoria em sua tribo. Toda noite ao redor do fogo, [PAWN_pronoun] trasmitiria conhecimento antigo e sabedoria útil através de histórias.</LoreKeeper51.baseDesc>
+  <LoreKeeper51.baseDesc>[PAWN_nameDef] era u{PAWN_gender ? m : ma} de uma longa linhagem de guardiões da sabedoria em sua tribo. Toda noite ao redor do fogo, [PAWN_pronoun] trasmitiria conhecimento antigo e sabedoria útil através de histórias.</LoreKeeper51.baseDesc>
   <!-- EN: lore keeper -->
   <LoreKeeper51.title>Guardião da sabedoria</LoreKeeper51.title>
   <!-- EN: keeper -->
@@ -184,7 +184,7 @@
   <VengefulHunter32.titleShort>Vingativo</VengefulHunter32.titleShort>
   
   <!-- EN: [PAWN_nameDef] was a fearsome warrior, proficient with many weapons. [PAWN_pronoun] participated in many battles. -->
-  <Warrior94.baseDesc>[PAWN_nameDef] foi um{PAWN_gender ? m : ma} guerreiro{PAWN_gender ? o : a} temível, proficiente com muitas armas. [PAWN_pronoun] participou de muitas batalhas.</Warrior94.baseDesc>
+  <Warrior94.baseDesc>[PAWN_nameDef] foi u{PAWN_gender ? m : ma} guerreir{PAWN_gender ? o : a} temível, proficiente com muitas armas. [PAWN_pronoun] participou de muitas batalhas.</Warrior94.baseDesc>
   <!-- EN: warrior -->
   <Warrior94.title>Guerreiro</Warrior94.title>
   <!-- EN: warrior -->

--- a/Core/DefInjected/BackstoryDef/Tribal_Adult.xml
+++ b/Core/DefInjected/BackstoryDef/Tribal_Adult.xml
@@ -130,9 +130,9 @@
   <!-- EN: [PAWN_nameDef] often feigned sickness in order to avoid [PAWN_possessive] responsibilities. While resting in the sick hut, [PAWN_pronoun] told stories to the children. -->
   <Malingerer28.baseDesc>[PAWN_nameDef] frequentemente fingia estar doente para evitar suas responsabilidades. Enquanto estava descansando na cabana dos doentes, [PAWN_pronoun] contava histórias para as crianças.</Malingerer28.baseDesc>
   <!-- EN: malingerer -->
-  <Malingerer28.title>Falso doente</Malingerer28.title>
+  <Malingerer28.title>Fingidor</Malingerer28.title>
   <!-- EN: malingerer -->
-  <Malingerer28.titleShort>Falso doente</Malingerer28.titleShort>
+  <Malingerer28.titleShort>Fingidor</Malingerer28.titleShort>
   
   <!-- EN: Because of [PAWN_possessive] quiet wisdom and great strength, [PAWN_nameDef] became the spiritual guide for [PAWN_possessive] tribe. [PAWN_pronoun] had a special connection with the great spirit of the muffalo. -->
   <MuffaloShaman95.baseDesc>Por causa de sua silenciosa sabedoria e grande força, [PAWN_nameDef] se tornou {PAWN_gender ? o : a} guia espiritual de sua tribo. [PAWN_pronoun] tinha uma conexão especial com o grande espírito do múfalo.</MuffaloShaman95.baseDesc>
@@ -158,7 +158,7 @@
   <!-- EN: [PAWN_nameDef] prepared meals from the plants and animals brought in by gatherers, farmers, and hunters of [PAWN_possessive] tribe. [PAWN_pronoun] had to make sure it was calorie-efficient, long-lasting, and healthy. [PAWN_pronoun] often processed and sometime gathered plants [PAWN_objective]self. -->
   <StewKeeper95.baseDesc>[PAWN_nameDef] preparava refeições com as plantas e animais trazidos por coletores, agricultores e caçadores de sua tribo. [PAWN_pronoun] tinha que garantir que as refeições, fossem eficientes em calorias, duradouras e saudáveis. Muitas vezes [PAWN_pronoun] processava as plantas coletadas por si mesm{PAWN_gender ? o : a}.</StewKeeper95.baseDesc>
   <!-- EN: stew keeper -->
-  <StewKeeper95.title>Cozinheiro rústico</StewKeeper95.title>
+  <StewKeeper95.title>Cozinheiro de sopa</StewKeeper95.title>
   <!-- EN: stewkeeper -->
   <StewKeeper95.titleShort>Cozinheiro</StewKeeper95.titleShort>
   

--- a/Core/DefInjected/BackstoryDef/Tribal_Child.xml
+++ b/Core/DefInjected/BackstoryDef/Tribal_Child.xml
@@ -23,7 +23,7 @@
   <BuddingArtist44.titleShort>Artista</BuddingArtist44.titleShort>
   
   <!-- EN: [PAWN_nameDef] tormented other children for fun. To keep [PAWN_objective] busy, an elder assigned [PAWN_objective] to a hunting party at an early age. -->
-  <Bully70.baseDesc>[PAWN_nameDef] atormentou outras crianças por diversão. Para mantê-l{pawn_gender ? o : a} ocupad{PAWN_gender ? o : a}, um ancião {pawn_gender ? o : a} designou para uma caçada em sua tenra idade.</Bully70.baseDesc>
+  <Bully70.baseDesc>[PAWN_nameDef] atormentou outras crianças por diversão. Para mantê-l{PAWN_gender ? o : a} ocupad{PAWN_gender ? o : a}, um ancião {PAWN_gender ? o : a} designou para uma caçada em sua tenra idade.</Bully70.baseDesc>
   <!-- EN: bully -->
   <Bully70.title>Valentão</Bully70.title>
   <!-- EN: bully -->
@@ -76,7 +76,7 @@
   <!-- EN: scavenger -->
   <Scavenger22.title>Caçador de tesouros</Scavenger22.title>
   <!-- EN: scavenger -->
-  <Scavenger22.titleShort>Caçado de tesouros</Scavenger22.titleShort>
+  <Scavenger22.titleShort>Caçador de tesouros</Scavenger22.titleShort>
   
   <!-- EN: [PAWN_nameDef]'s entire tribe was wiped out in a raid. Though [PAWN_pronoun] was adopted by another group, [PAWN_pronoun] was emotionally scarred, and preferred to stay near home, cooking and tending crops. -->
   <SoleSurvivor21.baseDesc>A tribo inteira de [PAWN_nameDef] foi exterminada em um ataque. Embora tenha sido adotad{PAWN_gender ? o : a} por outro grupo, [PAWN_pronoun] estava emocionalmente traumatizad{PAWN_gender ? o : a} e preferia ficar perto de sua moradia, cozinhando e cuidando das plantações.</SoleSurvivor21.baseDesc>

--- a/Core/DefInjected/BackstoryDef/Tribal_Child.xml
+++ b/Core/DefInjected/BackstoryDef/Tribal_Child.xml
@@ -2,14 +2,14 @@
 <LanguageData>
   
   <!-- EN: [PAWN_nameDef] was born sickly. Thinking that [PAWN_pronoun] would only burden the tribe, [PAWN_possessive] parents exposed [PAWN_objective] to the elements. Somehow, [PAWN_pronoun] survived. -->
-  <AbandonedChild23.baseDesc>[PAWN_nameDef] nasceu doente. Pensando que [PAWN_pronoun] só sobrecarregaria a tribo, os seus pais lhe expuseram aos elementos. De alguma forma, [PAWN_pronoun] sobreviveu.</AbandonedChild23.baseDesc>
+  <AbandonedChild23.baseDesc>[PAWN_nameDef] nasceu doente. Pensando que [PAWN_pronoun] só sobrecarregaria a tribo, os seus pais lhe expuseram as intempéries da natureza. De alguma forma, [PAWN_pronoun] sobreviveu.</AbandonedChild23.baseDesc>
   <!-- EN: abandoned child -->
   <AbandonedChild23.title>Criança abandonada</AbandonedChild23.title>
   <!-- EN: abandoned -->
   <AbandonedChild23.titleShort>Abandonado</AbandonedChild23.titleShort>
   
   <!-- EN: Rather than socialize with the other children, [PAWN_nameDef] preferred to get lost in literature. [PAWN_pronoun] taught [PAWN_objective]self to read at an early age with books bought from passing traders. -->
-  <Bookworm19.baseDesc>Em vez de socializar com as outras crianças, [PAWN_nameDef] preferia se perder na literatura. Desde cedo, [PAWN_pronoun] aprendeu a ler sozinho, com livros comprados de comerciantes que passavam.</Bookworm19.baseDesc>
+  <Bookworm19.baseDesc>Em vez de socializar com as outras crianças, [PAWN_nameDef] preferia se perder na literatura. Desde cedo, [PAWN_pronoun] aprendeu a ler sozinh{PAWN_gender ? o : a}, com livros comprados de comerciantes que passavam.</Bookworm19.baseDesc>
   <!-- EN: bookworm -->
   <Bookworm19.title>Devorador de livros</Bookworm19.title>
   <!-- EN: bookworm -->
@@ -23,7 +23,7 @@
   <BuddingArtist44.titleShort>Artista</BuddingArtist44.titleShort>
   
   <!-- EN: [PAWN_nameDef] tormented other children for fun. To keep [PAWN_objective] busy, an elder assigned [PAWN_objective] to a hunting party at an early age. -->
-  <Bully70.baseDesc>[PAWN_nameDef] atormentou outras crianças por diversão. Para manter-lo ocupado, um ancião designou [PAWN_objective] para uma caçada em tenra idade.</Bully70.baseDesc>
+  <Bully70.baseDesc>[PAWN_nameDef] atormentou outras crianças por diversão. Para mantê-l{pawn_gender ? o : a} ocupad{PAWN_gender ? o : a}, um ancião {pawn_gender ? o : a} designou para uma caçada em sua tenra idade.</Bully70.baseDesc>
   <!-- EN: bully -->
   <Bully70.title>Valentão</Bully70.title>
   <!-- EN: bully -->
@@ -37,21 +37,21 @@
   <CaveChild30.titleShort>Criança de caverna</CaveChild30.titleShort>
   
   <!-- EN: As a baby, [PAWN_nameDef] was the only survivor of a deadly spacecraft crash. A passing tribe discovered [PAWN_objective] in the wreckage and adopted [PAWN_objective]. -->
-  <CrashBaby32.baseDesc>Quando bebê, [PAWN_nameDef] foi o único sobrevivente de um acidente mortal com uma espaçonave. Uma tribo de passagem o descobriu nos destroços e o adotou.</CrashBaby32.baseDesc>
+  <CrashBaby32.baseDesc>Quando bebê, [PAWN_nameDef] foi {PAWN_gender ? o : a} únic{PAWN_gender ? o : a} sobrevivente de um acidente mortal com uma espaçonave. Uma tribo que estava de passagem {PAWN_gender ? o : a} descobriu nos destroços e {PAWN_gender ? o : a} adotou.</CrashBaby32.baseDesc>
   <!-- EN: crash baby -->
   <CrashBaby32.title>Bebê acidentado</CrashBaby32.title>
   <!-- EN: crashbaby -->
   <CrashBaby32.titleShort>Bebê acidentado</CrashBaby32.titleShort>
   
   <!-- EN: [PAWN_nameDef] was responsible for keeping the tribe's fire going. [PAWN_pronoun] took this responsibility very seriously. -->
-  <FireKeeper44.baseDesc>Em sua infância, [PAWN_nameDef] foi responsável por manter o fogo da tribo em movimento. [PAWN_pronoun] tomou esta responsabilidade muito a sério.</FireKeeper44.baseDesc>
+  <FireKeeper44.baseDesc>Em sua infância, [PAWN_nameDef] foi responsável por manter o fogo da tribo aceso. [PAWN_pronoun] levou esta responsabilidade muito a sério.</FireKeeper44.baseDesc>
   <!-- EN: fire keeper -->
   <FireKeeper44.title>Guardião do fogo</FireKeeper44.title>
   <!-- EN: firekeep -->
   <FireKeeper44.titleShort>Guardião do fogo</FireKeeper44.titleShort>
   
   <!-- EN: [PAWN_nameDef] tended the muffalo herds, keeping them safe from predators and treating sick animals. It was quiet work, but [PAWN_pronoun] enjoyed being away from people. -->
-  <Herder19.baseDesc>Quando criança, [PAWN_nameDef] cuidava dos rebanhos de múfalo da tribo, os mantendo a salvo de predadores e tratando os doentes. Foi um trabalho silencioso, mas [PAWN_pronoun] gostava de estar longe das pessoas.</Herder19.baseDesc>
+  <Herder19.baseDesc>[PAWN_nameDef] cuidava dos rebanhos de múfalos, mantendo-os protegidos de predadores e tratando animais doentes. Foi um trabalho silencioso, mas [PAWN_pronoun] gostava de estar longe das pessoas.</Herder19.baseDesc>
   <!-- EN: herder -->
   <Herder19.title>Pastor</Herder19.title>
   <!-- EN: herder -->
@@ -60,26 +60,26 @@
   <!-- EN: [PAWN_nameDef]'s overprotective parents encouraged [PAWN_objective] to stay at home nearly every day. Though [PAWN_pronoun] had a lot of time to read and pursue crafting hobbies, [PAWN_pronoun] never developed normal social skills. -->
   <Hideaway7.baseDesc>Os pais superprotetores de [PAWN_nameDef] encorajavam [PAWN_pronoun] a ficar em casa quase todos os dias. Embora [PAWN_pronoun] tivesse muito tempo para ler e seguir hobbies, [PAWN_pronoun] nunca desenvolveu habilidades sociais normais.</Hideaway7.baseDesc>
   <!-- EN: hideaway -->
-  <Hideaway7.title>Recluso</Hideaway7.title>
+  <Hideaway7.title>Escondido</Hideaway7.title>
   <!-- EN: hideaway -->
-  <Hideaway7.titleShort>Recluso</Hideaway7.titleShort>
+  <Hideaway7.titleShort>Escondido</Hideaway7.titleShort>
   
   <!-- EN: [PAWN_nameDef] didn't learn to speak until [PAWN_pronoun] was nearly five years old. Even then [PAWN_pronoun] preferred to keep to [PAWN_objective]self.\n\nTo the chagrin of [PAWN_possessive] caretakers, [PAWN_pronoun] made a habit of wandering off to live in the wilderness for weeks at a time. -->
-  <ReclusiveChild81.baseDesc>[PAWN_nameDef] não aprendeu a falar até que [PAWN_pronoun] teve quase 5 anos de idade, e, mesmo assim, [PAWN_pronoun] preferiu manter para si mesmo. Quando [PAWN_pronoun] estava no início de sua adolescência, [PAWN_pronoun] fez um hábito de vaguear fora da aldeia para viver na selvageria por semanas de cada vez.</ReclusiveChild81.baseDesc>
+  <ReclusiveChild81.baseDesc>[PAWN_nameDef] não aprendeu a falar até [PAWN_pronoun] ter quase 5 anos de idade. Mesmo assim, [PAWN_pronoun] preferiu manter isso para si mesmo.\n\nPara desgosto dos seus cuidadores, [PAWN_pronoun] criou o hábito de vagar para viver em regiões selvagens por semanas a fio.</ReclusiveChild81.baseDesc>
   <!-- EN: reclusive child -->
-  <ReclusiveChild81.title>Criança reclusiva</ReclusiveChild81.title>
+  <ReclusiveChild81.title>Criança reclusa</ReclusiveChild81.title>
   <!-- EN: reclusive -->
-  <ReclusiveChild81.titleShort>Reclusivo</ReclusiveChild81.titleShort>
+  <ReclusiveChild81.titleShort>Recluso</ReclusiveChild81.titleShort>
   
   <!-- EN: [PAWN_nameDef] spent [PAWN_possessive] childhood escaping grunt work to go digging through wrecks and ruins for treasures. [PAWN_possessive] natural curiosity got [PAWN_objective] into a lot of trouble, but it also yielded many interesting finds. -->
   <Scavenger22.baseDesc>[PAWN_nameDef] passou a infância escapando do trabalho pesado para vasculhar destroços e ruínas em busca de tesouros. Sua curiosidade natural meteu-lhe em muitos problemas, mas também gerou muitos achados interessantes.</Scavenger22.baseDesc>
   <!-- EN: scavenger -->
-  <Scavenger22.title>Catador</Scavenger22.title>
+  <Scavenger22.title>Caçador de tesouros</Scavenger22.title>
   <!-- EN: scavenger -->
-  <Scavenger22.titleShort>Catador</Scavenger22.titleShort>
+  <Scavenger22.titleShort>Caçado de tesouros</Scavenger22.titleShort>
   
   <!-- EN: [PAWN_nameDef]'s entire tribe was wiped out in a raid. Though [PAWN_pronoun] was adopted by another group, [PAWN_pronoun] was emotionally scarred, and preferred to stay near home, cooking and tending crops. -->
-  <SoleSurvivor21.baseDesc>A tribo inteira de [PAWN_nameDef] foi exterminada em um ataque. Embora tenha sido adotado por outro grupo, [PAWN_pronoun] estava emocionalmente marcado e preferia ficar perto de casa, cozinhando e cuidando das plantações.</SoleSurvivor21.baseDesc>
+  <SoleSurvivor21.baseDesc>A tribo inteira de [PAWN_nameDef] foi exterminada em um ataque. Embora tenha sido adotad{PAWN_gender ? o : a} por outro grupo, [PAWN_pronoun] estava emocionalmente traumatizad{PAWN_gender ? o : a} e preferia ficar perto de sua moradia, cozinhando e cuidando das plantações.</SoleSurvivor21.baseDesc>
   <!-- EN: sole survivor -->
   <SoleSurvivor21.title>Único sobrevivente</SoleSurvivor21.title>
   <!-- EN: survivor -->
@@ -93,7 +93,7 @@
   <TribeChild40.titleShort>Tribal</TribeChild40.titleShort>
   
   <!-- EN: As a child, [PAWN_nameDef] returned to [PAWN_possessive] village to find that it had been wiped out by bandits. [PAWN_pronoun] swore revenge on the attackers and began a violent rampage across the wilderness. -->
-  <VengefulChild43.baseDesc>Quando criança, [PAWN_nameDef] retornou à sua aldeia para descobrir que tinha sido dizimada por bandidos. [PAWN_pronoun] jurou vingança contra os atacantes e começou um violento tumulto através da selvageria.</VengefulChild43.baseDesc>
+  <VengefulChild43.baseDesc>Quando criança, [PAWN_nameDef] retornou à sua aldeia para descobrir que tinha sido dizimada por bandidos. [PAWN_pronoun] jurou vingança contra os atacantes e começou uma violenta investida através da selvageria.</VengefulChild43.baseDesc>
   <!-- EN: vengeful child -->
   <VengefulChild43.title>Criança vingativa</VengefulChild43.title>
   <!-- EN: vengeful -->

--- a/Core/DefInjected/BackstoryDef/Tribal_Child.xml
+++ b/Core/DefInjected/BackstoryDef/Tribal_Child.xml
@@ -60,9 +60,9 @@
   <!-- EN: [PAWN_nameDef]'s overprotective parents encouraged [PAWN_objective] to stay at home nearly every day. Though [PAWN_pronoun] had a lot of time to read and pursue crafting hobbies, [PAWN_pronoun] never developed normal social skills. -->
   <Hideaway7.baseDesc>Os pais superprotetores de [PAWN_nameDef] encorajavam [PAWN_pronoun] a ficar em casa quase todos os dias. Embora [PAWN_pronoun] tivesse muito tempo para ler e seguir hobbies, [PAWN_pronoun] nunca desenvolveu habilidades sociais normais.</Hideaway7.baseDesc>
   <!-- EN: hideaway -->
-  <Hideaway7.title>Escondido</Hideaway7.title>
+  <Hideaway7.title>Isolado</Hideaway7.title>
   <!-- EN: hideaway -->
-  <Hideaway7.titleShort>Escondido</Hideaway7.titleShort>
+  <Hideaway7.titleShort>Isolado</Hideaway7.titleShort>
   
   <!-- EN: [PAWN_nameDef] didn't learn to speak until [PAWN_pronoun] was nearly five years old. Even then [PAWN_pronoun] preferred to keep to [PAWN_objective]self.\n\nTo the chagrin of [PAWN_possessive] caretakers, [PAWN_pronoun] made a habit of wandering off to live in the wilderness for weeks at a time. -->
   <ReclusiveChild81.baseDesc>[PAWN_nameDef] não aprendeu a falar até [PAWN_pronoun] ter quase 5 anos de idade. Mesmo assim, [PAWN_pronoun] preferiu manter isso para si mesmo.\n\nPara desgosto dos seus cuidadores, [PAWN_pronoun] criou o hábito de vagar para viver em regiões selvagens por semanas a fio.</ReclusiveChild81.baseDesc>


### PR DESCRIPTION
Reformulação das Histórias de Fundo que envolvem adultos e crianças tribais




### **📝 Alterações Propostas:**
<!--
    Especifique as alterações propostas neste pull request. 
-->
-Principais Mudanças: a) Fazer com que o gênero das palavras na descrição mudem de acordo com o sexo do peão; b) ajustar descrições que não têm ligação com o texto original; c) reajustar descrições que têm pequenas alterações para uniformizar com a lingua original

-Pontos de Atenção: "treehouse builder" se tronou "Construtor de casas" para não ficar cortado por não caber no campo de informações do peão (Adult_Tribal, linhas 175 e 177)



### **📜 Requisitos:**
<!--
    Mesmo que cumpra com todos os requisitos, mantenha-os aqui para fins de registro. Apenas coloque um *x* em cada item cumprido.

    Caso não faça parte da equipe, o pull request não será aceito. Para entrar na equipe, verifique o [MANUAL DO TRADUTOR](https://github.com/Ludeon/RimWorld-PortugueseBrazilian/blob/master/Manuais/manualDoTradutor.md)
-->

 - [x] Você testou as traduções antes de publicar o pull request?
 - [x] Você verificou se outro pull request tem a mesma proposta que o seu?
 - [x] Você verificou se sua fork e sua branch estão atualizadas?
 - [x] Você já faz parte da equipe de tradução?

### **💬 Comentários Adicionais:**
<!--
    Caso queira comentar algo a mais, sinta-se a vontade para fazer isso aqui.
-->
As demais histórias de fundo estão sendo ajustadas e serão enviadas de acordo com a categoria

Qualquer sugestão é bem vinda!
