### PR TITLE
Remoção do Espaço no Início da Descrição de Forester96

### DIFF
--- a/Core/Backstories/Backstories.xml
+++ b/Core/Backstories/Backstories.xml
@@ -2510,7 +2510,7 @@
     <!-- EN: forester -->
     <titleShort>silvicultor</titleShort>
     <!-- EN: [PAWN_nameDef] grew and harvested forests. [PAWN_pronoun] understood both the practical challenges of soil types, wind, and rain, as well as the long-term planning of forest growth. -->
-    <desc> [PAWN_nameDef] plantou e colheu na foresta. [PAWN_pronoun] aprendeu os desafios mais comuns com os tipos de solo, o vento e a chuva, assim como a maneira correta de plantar toda uma floresta no largo prazo.</desc>
+    <desc>[PAWN_nameDef] plantou e colheu na foresta. [PAWN_pronoun] aprendeu os desafios mais comuns com os tipos de solo, o vento e a chuva, assim como a maneira correta de plantar toda uma floresta no largo prazo.</desc>
   </Forester96>
   
   <ForestProwler15>


### PR DESCRIPTION
### **📝 Alterações Propostas:**
Remova o espaço em branco do início da descrição de Forester96

### **📜 Requisitos:**
<!--
    Mesmo que cumpra com todos os requisitos, mantenha-os aqui para fins de registro. Apenas coloque um *x* em cada item cumprido.

    Caso não faça parte da equipe, o pull request não será aceito. Para entrar na equipe, verifique o [MANUAL DO TRADUTOR](https://github.com/Ludeon/RimWorld-PortugueseBrazilian/blob/master/Manuais/manualDoTradutor.md)
-->

 - [x] Você testou as traduções antes de publicar o pull request?
 - [x] Você verificou se outro pull request tem a mesma proposta que o seu?
 - [x] Você verificou se sua fork e sua branch estão atualizadas?
 - [ ] Você já faz parte da equipe de tradução?

### **💬 Comentários Adicionais:**
Não faço parte da equipe de tradução. Esta é uma correção muito pequena. Você não precisa usar esta pull request para o problema #279
